### PR TITLE
Find more submit buttons

### DIFF
--- a/background.js
+++ b/background.js
@@ -221,7 +221,7 @@ var onMessage = (request, sender, response) => {
                       onChange(passElement);
                       if ('${request.detail}' !== 'no-submit') {
                         // submit
-                        const button = form.querySelector('input[type=submit]') || form.querySelector('[type=submit]');
+                        const button = form.querySelector('input[type=submit]') || form.querySelector('button:not([type=reset i]):not([type=button i])');
                         if (button) {
                           button.click();
                         }


### PR DESCRIPTION
The only [type=submit] that is legal is a button element. And a button
element with a missing type attribute or a value for its type attribute
that is not “reset” or “button” is defined as being a submit button:

https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type

I have encountered at least three login forms that use as their submit
buttons a <button> element with no or an empty type attribute; these
were not formerly caught by this extension, making it just call
form.submit() instead, which was in each case the wrong thing to do.
With this change, they should work fine.